### PR TITLE
Adding OracleLinux specific playbook

### DIFF
--- a/vars/OracleLinux.yml
+++ b/vars/OracleLinux.yml
@@ -1,0 +1,7 @@
+--
+ntp_package: ntp
+ntp_service: ntpd
+ssh_service: sshd
+grubcfg_location: /boot/grub/grub.conf
+cracklib_package: cracklib
+pam_password_file: /etc/pam.d/system-auth


### PR DESCRIPTION
@blackbaud/data-pipeline @MarsDominion Hey Mark, we need this file added into linux hardening because we're using an Oracle AMI that needs to call out to it when it does the hardening. Can you merge this in or let us know what you'd like to see changed?